### PR TITLE
reacting: qualify boost::make_shared to fix build on modern toolchains

### DIFF
--- a/apps/reacting/antioch_constitutive.cpp
+++ b/apps/reacting/antioch_constitutive.cpp
@@ -286,7 +286,7 @@ void antioch_constitutive::init_antioch()
 {
     WARN0("antioch_constitutive is not fully functional yet!");
 
-    mixture    = make_shared<Antioch::ChemicalMixture<real_t> >(species_names);
+    mixture    = boost::make_shared<Antioch::ChemicalMixture<real_t> >(species_names);
     reactions  = make_shared<Antioch::ReactionSet<real_t> >(*mixture);
     cea_thermo = make_shared<Antioch::CEAThermodynamics<real_t> >(*mixture);
     sm_thermo  = make_shared<Antioch::StatMechThermodynamics<real_t> >(*mixture);

--- a/apps/reacting/main_init.cpp
+++ b/apps/reacting/main_init.cpp
@@ -110,7 +110,7 @@ suzerain::reacting::driver_init::run(int argc, char **argv)
     timedef = make_shared<support::definition_time>(/* per Venugopal */ 0.72);
 
     // Establish default MMS parameters and plug into program options
-    msoln = make_shared<manufactured_solution>(
+    msoln = boost::make_shared<manufactured_solution>(
             manufactured_solution::default_caption
             + " (active only when --mms supplied)");
     options.add_definition(msoln->isothermal_channel());

--- a/apps/reacting/operator_hybrid.cpp
+++ b/apps/reacting/operator_hybrid.cpp
@@ -755,7 +755,7 @@ void isothermal_hybrid_linear_operator::invert_mass_plus_scaled_operator(
     if (species_solver.size()>0) {
         // FIXME: permit upper_T and upper_cs
         species_bc_enforcer =
-            make_shared<MassFractionPATPTEnforcer>(
+            boost::make_shared<MassFractionPATPTEnforcer>(
                 *(species_solver[0]), isospec.lower_cs, nwalls);
     }
 


### PR DESCRIPTION
## Summary

Fixes a compile break in the `reacting` application on modern toolchains
(GCC 13 / Boost 1.83 / C++11+). Three `make_shared` call sites are called
with arguments living in namespace `std` (`std::vector<std::string>`,
`std::string`), so argument-dependent lookup pulls in `std::make_shared`
alongside the `using boost::make_shared` brought in via `common.hpp`,
making the unqualified call ambiguous.

Each affected site is qualified with `boost::` so it matches the
`boost::shared_ptr` member it is assigned to:

- `apps/reacting/antioch_constitutive.cpp` — `ChemicalMixture` from species names
- `apps/reacting/main_init.cpp` — `manufactured_solution` from a caption string
- `apps/reacting/operator_hybrid.cpp` — `MassFractionPATPTEnforcer`

The `perfect` application is unaffected because its `make_shared`
arguments are not `std::` types.

## Validation

Built on Ubuntu 24.04 with GCC 13, OpenMPI, MKL, and the optional GRVY,
Antioch (0.4.0), and SymPy components. Full tree (core library, both
solver apps, doxygen HTML, and the LaTeX writeups) builds cleanly.

`make check`: **120 PASS, 1 XFAIL**. The core library unit tests, largo,
and the `perfect` solver (13/13) all pass.

## Out of scope

The `reacting` application's 11 tests still fail at runtime — they
segfault inside Antioch's Blottner transport-data reader on the `CPAir`
model species (which has no entry in Antioch's default data files). That
path is self-described as "not fully functional yet" in the source and is
a separate, pre-existing issue; this PR only restores compilation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWBcYUqWEKknpsNwtBnG5W

---
_Generated by [Claude Code](https://claude.ai/code/session_01RWBcYUqWEKknpsNwtBnG5W)_