### PR TITLE
Update README links for GRVY and underling to GitHub URLs

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,7 +1,7 @@
 karl     = Karl Schulz     <karl@ices.utexas.edu>
 nick     = Nicholas Malaya <nick@ices.utexas.edu>
 oliver   = Todd A. Oliver  <oliver@ices.utexas.edu>
-rhys     = Rhys Ulerich    <rhys@ices.utexas.edu>
+rhys     = Rhys Ulerich    <rhys.ulerich@gmail.com>
 rmoser   = Robert D. Moser <rmoser@ices.utexas.edu>
 roystgnr = Roy Stogner     <roystgnr@ices.utexas.edu>
 topalian = Victor Topalian <topalian@ices.utexas.edu>

--- a/README
+++ b/README
@@ -23,10 +23,10 @@ The code depends upon the following libraries:
 
 The following optional dependencies are recommended for full functionality:
 
-    1) GRVY from https://red.ices.utexas.edu/projects/software/wiki/GRVY
+    1) GRVY from https://github.com/hpcsci/grvy
     2) SymPy from http://sympy.org
     3) Antioch from https://github.com/libantioch/antioch
-    4) underling from https://red.ices.utexas.edu/projects/underling
+    4) underling from https://github.com/RhysU/underling
 
 On Ubuntu 24.04, most required and optional dependencies are available as
 system packages.  Install the build toolchain:

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 dnl ------------------------------------------------
 dnl Package overview
 dnl ------------------------------------------------
-AC_INIT([suzerain],[0.1.7],[rhys@ices.utexas.edu],[suzerain],[https://red.ices.utexas.edu/projects/suzerain])
+AC_INIT([suzerain],[0.1.7],[rhys@ices.utexas.edu],[suzerain],[https://github.com/RhysU/suzerain])
 AC_REVISION([$Id$])
 
 dnl ------------------------------------------------

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 dnl ------------------------------------------------
 dnl Package overview
 dnl ------------------------------------------------
-AC_INIT([suzerain],[0.1.7],[rhys@ices.utexas.edu],[suzerain],[https://github.com/RhysU/suzerain])
+AC_INIT([suzerain],[0.1.7],[rhys.ulerich@gmail.com],[suzerain],[https://github.com/RhysU/suzerain])
 AC_REVISION([$Id$])
 
 dnl ------------------------------------------------

--- a/largo/AUTHORS
+++ b/largo/AUTHORS
@@ -5,4 +5,4 @@ contributors from PECOS include:
   Victor Topalian <topalian@ices.utexas.edu>
   Todd Oliver <oliver@ices.utexas.edu>
   Robert D Moser <rmoser@ices.utexas.edu>
-  Rhys Ulerich <rhys@ices.utexas.edu>
+  Rhys Ulerich <rhys.ulerich@gmail.com>

--- a/writeups/perfectgas.tex
+++ b/writeups/perfectgas.tex
@@ -100,7 +100,7 @@
 \author{Rhys Ulerich}
 \address{Institute for Computational Engineering and Sciences\\
          The University of Texas at Austin}
-\email{rhys@ices.utexas.edu}
+\email{rhys.ulerich@gmail.com}
 \date{\today}
 \maketitle
 \renewcommand{\contentsname}{} % No idea why "Contents" appears in wrong location


### PR DESCRIPTION
Replace defunct red.ices.utexas.edu URLs with current GitHub locations:
hpcsci/grvy and RhysU/underling.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011BPVjkG37MBAuTvWL7eUPu