### PR TITLE
Fix documentation, improve numerical stability, and refactor code

### DIFF
--- a/suzerain/ar.hpp
+++ b/suzerain/ar.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012, 2013 Rhys Ulerich
+// Copyright (C) 2012, 2013, 2026 Rhys Ulerich
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -97,7 +97,7 @@ namespace ar
  * message \c msg.
  *
  * This macro is intended for <tt>assert</tt>-like checks which should always
- * be performed regardless of whether or not \c NDEBUG is <tt>#define</tt>d.
+ * be performed regardless of whether or not \c NDEBUG is <tt>\#define</tt>d.
  */
 #define AR_ENSURE_MSGEXCEPT(expr, msg, except) \
     if (!(expr)) throw except(msg)
@@ -108,7 +108,7 @@ namespace ar
  * with message \c msg.
  *
  * This macro is intended for <tt>assert</tt>-like checks which should always
- * be performed regardless of whether or not \c NDEBUG is <tt>#define</tt>d.
+ * be performed regardless of whether or not \c NDEBUG is <tt>\#define</tt>d.
  */
 #define AR_ENSURE_MSG(expr, msg) \
     AR_ENSURE_MSGEXCEPT(expr, msg, std::logic_error)
@@ -118,7 +118,7 @@ namespace ar
  * evaluates to boolean \c false, then a <tt>std::logic_error</tt> is thrown.
  *
  * This macro is intended for <tt>assert</tt>-like checks which should always
- * be performed regardless of whether or not \c NDEBUG is <tt>#define</tt>d.
+ * be performed regardless of whether or not \c NDEBUG is <tt>\#define</tt>d.
  */
 #define AR_ENSURE(expr) \
     AR_ENSURE_MSG(expr, AR_STRINGIFY(expr)" false")
@@ -129,7 +129,7 @@ namespace ar
  * <tt>std::invalid_argument</tt> is thrown.
  *
  * This macro is intended for <tt>assert</tt>-like checks which should always
- * be performed regardless of whether or not \c NDEBUG is <tt>#define</tt>d.
+ * be performed regardless of whether or not \c NDEBUG is <tt>\#define</tt>d.
  */
 #define AR_ENSURE_ARG(expr) \
     AR_ENSURE_MSGEXCEPT(expr, AR_STRINGIFY(expr)" false", std::invalid_argument)
@@ -139,7 +139,7 @@ namespace ar
  * evaluates to boolean \c false, then an exception \c except is thrown.
  *
  * This macro is intended for <tt>assert</tt>-like checks which should always
- * be performed regardless of whether or not \c NDEBUG is <tt>#define</tt>d.
+ * be performed regardless of whether or not \c NDEBUG is <tt>\#define</tt>d.
  */
 #define AR_ENSURE_EXCEPT(expr, except) \
     AR_ENSURE_MSGEXCEPT(expr, AR_STRINGIFY(expr)" false", except)
@@ -443,14 +443,19 @@ ValueType welford_inner_product(InputIterator1 first1,
 /**
  * Robustly compute negative one half the reflection coefficient assuming
  * \f$\vec{a}\f$ and \f$\vec{b}\f$ contain real-valued backward and forward
- * prediction error sequences, respectively.
+ * prediction error sequences, respectively.  Zero is returned whenever the
+ * reflection coefficient numerator is identically zero, as otherwise
+ * constant zero signals produce undesired NaN reflection coefficients.
+ * The constant zero special case does not defeat NaN detection as any data
+ * introducing NaN into the denominator must introduce NaN into the numerator.
  *
  * @param[in] a_first Beginning of the first input range \f$\vec{a}\f$.
  * @param[in] a_last  Exclusive end of first input range \f$\vec{a}\f$.
  * @param[in] b_first Beginning of the second input range \f$\vec{b}\f$.
  *
  * @return \f$\frac{\vec{a}\cdot\vec{b}}
- *                 {\vec{a}\cdot\vec{a} + \vec{b}\cdot\vec{b}}\f$.
+ *                 {\vec{a}\cdot\vec{a} + \vec{b}\cdot\vec{b}}\f$
+ *         when that numerator is nonzero, else zero.
  *
  * @see Wikipedia's article on <a href="">Kahan summation</a> for
  *      background on how the accumulation error is reduced in the result.
@@ -490,7 +495,9 @@ negative_half_reflection_coefficient(InputIterator1 a_first,
         ns = nt;
     }
 
-    return (ns + nc) / (ds + dc);      // Correct final sums and form ratio
+    return ns + nc == 0                // Does special zero case apply?
+        ? 0                            // Yes, to avoid NaN from 0 / 0
+        : (ns + nc) / (ds + dc);       // No, correct final sums and form ratio
 }
 #else
 #warning Using Non-Kahan version of ar::negative_half_reflection_coefficient.
@@ -502,11 +509,13 @@ negative_half_reflection_coefficient(InputIterator1 a_first,
     {
         ValueType xa  = *a_first++;
         ValueType xb  = *b_first++;
-        ns           += xa * xb;
-        ds           += xa * xa + xb * xb;
+        ns           += xa * xb;            // Numerator
+        ds           += xa * xa + xb * xb;  // Denominator
     }
 
-    return ns / ds;
+    return ns == 0                          // Does special zero case apply?
+        ? 0                                 // Yes, to avoid NaN from 0 / 0
+        : ns / ds;                          // No, form ratio
 }
 #endif
 
@@ -515,94 +524,13 @@ negative_half_reflection_coefficient(InputIterator1 a_first,
 #endif
 
 /**
- * Fit an autoregressive model to stationary time series data using %Burg's
- * method.  That is, find coefficients \f$a_i\f$ such that the sum of the
- * squared errors in the forward predictions \f$x_n = -a_1 x_{n-1} - \dots -
- * a_p x_{n-p}\f$ and backward predictions \f$x_n = -a_1 x_{n+1} - \dots - a_p
- * x_{n+p}\f$ are both minimized.  Either a single model of given order or a
- * hierarchy of models up to and including a maximum order may fit.
+ * \copydoc burg_method(InputIterator,InputIterator,Value&,std::size_t&,OutputIterator1,OutputIterator2,OutputIterator3,OutputIterator4,const bool,const bool)
  *
- * The input data \f$\vec{x}\f$ are read from <tt>[data_first, data_last)</tt>
- * in a single pass.  The mean is computed, returned in \c mean, and \e
- * removed from further consideration whenever \c subtract_mean is true.
- * The estimated model parameters \f$a_i\f$ are output using \c params_first
- * with the behavior determined by the amount of data read, <tt>maxorder</tt>,
- * and the \c hierarchy flag:
- * <ul>
- *     <li>If \c hierarchy is \c false, only the \f$a_1, \dots,
- *         a_\text{maxorder}\f$ parameters for an AR(<tt>maxorder</tt>) process
- *         are output.</li>
- *     <li>If \c hierarchy is \c true, the <tt>maxorder*(maxorder+1)/2</tt>
- *         parameters \f$a_1, \dots, a_m\f$ for models AR(0), AR(1), AR(2),
- *         ..., AR(maxorder) are output.  Notice AR(0) has no parameters.
- *         </li>
- * </ul>
- * Note that the latter case is \e always computed; the \c hierarchy flag
- * merely controls what is output.  In both cases, the maximum order is limited
- * by the number of data samples provided and is output to \c maxorder.
- *
- * One mean squared discrepancy \f$\sigma^2_\epsilon\f$, also called the
- * innovation variance, and gain, defined as \f$\sigma^2_x /
- * \sigma^2_\epsilon\f$, are output for each model, including the trivial
- * zeroth order model when \c maxorder is zero or \c hierarchy is \c true,
- * using \c sigma2e_first and \c gain_first.  The autocorrelations for lags
- * <tt>[0,k]</tt> are output using \c autocor_first.  When \c hierarchy is \c
- * true, only lags <tt>[0,m]</tt> should be applied for some AR(<tt>m</tt>)
- * model.  Outputting the lag \c k autocorrelation is technically redundant as
- * it may be computed from \f$a_i\f$ and lags <tt>0, ..., k-1</tt>.
- * Autocovariances may be computed by multiplying the autocorrelations by the
- * gain times \f$\sigma^2_\epsilon\f$.
- *
- * The software aspects of the implementation differs from many other sources.
- * In particular,
- * <ul>
- *     <li>iterators are employed,</li>
- *     <li>the working precision is selectable using \c mean,</li>
- *     <li>the mean squared discrepancy calculation has been added,</li>
- *     <li>some loop index transformations have been performed,</li>
- *     <li>working storage may be passed into the method to reduce allocations
- *     across many invocations, and</li>
- *     <li>and all lower order models may be output during the recursion using
- *     \c hierarchy.</li>
- * </ul>
- * Gain and autocorrelation calculations have been added based on sections 5.2
- * and 5.3 of Broersen, P.  M.  T. Automatic autocorrelation and spectral
- * analysis.  Springer, 2006.  http://dx.doi.org/10.1007/1-84628-329-9.  The
- * classical algorithm, rather than the variant using denominator recursion due
- * to Andersen (http://dx.doi.org/10.1109/PROC.1978.11160), has been chosen as
- * the latter can be numerically unstable.
- *
- * @param[in]     data_first    Beginning of the input data range.
- * @param[in]     data_last     Exclusive end of the input data range.
- * @param[out]    mean          Mean of data.
- * @param[in,out] maxorder      On input, the maximum model order desired.
- *                              On output, the maximum model order computed.
- * @param[out]    params_first  Model parameters for a single model or
- *                              for an entire hierarchy of models.  At most
- *                              <tt>!hierarchy ? maxorder :
- *                              maxorder*(maxorder+1)/2</tt> values will be
- *                              output.
- * @param[out]    sigma2e_first The mean squared discrepancy for only
- *                              AR(<tt>maxorder</tt>) or for an entire
- *                              hierarchy.  Either one or at most
- *                              <tt>maxorder + 1</tt> values will be output.
- * @param[out]    gain_first    The model gain for only AR(<tt>maxorder</tt>)
- *                              or an entire hierarchy.  Either one or at most
- *                              <tt>maxorder + 1</tt> values will be output.
- * @param[out]    autocor_first Lag one through lag maxorder autocorrelations.
- *                              At most <tt>maxorder + 1</tt> values will be
- *                              output.
- * @param[in]     subtract_mean Should \c mean be subtracted from the data?
- * @param[in]     hierarchy     Should the entire hierarchy of estimated
- *                              models be output?
  * @param[in]     f             Working storage.  Reuse across invocations
  *                              may speed execution by avoiding allocations.
  * @param[in]     b             Working storage similar to \c f.
  * @param[in]     Ak            Working storage similar to \c f.
  * @param[in]     ac            Working storage similar to \c f.
- *
- * @returns the number data values processed within
- *          <tt>[data_first, data_last)</tt>.
  */
 template <class InputIterator,
           class Value,
@@ -626,13 +554,11 @@ std::size_t burg_method(InputIterator   data_first,
                         Vector&         Ak,
                         Vector&         ac)
 {
-    using std::bind2nd;
     using std::copy;
     using std::distance;
     using std::fill;
     using std::inner_product;
     using std::min;
-    using std::minus;
     using std::size_t;
 
     // Initialize f from [data_first, data_last) and fix number of samples
@@ -648,7 +574,9 @@ std::size_t burg_method(InputIterator   data_first,
     // Adjust, if necessary, to make sigma2e the second moment.
     if (subtract_mean)
     {
-        transform(f.begin(), f.end(), f.begin(), bind2nd(minus<Value>(), mean));
+        for (typename Vector::iterator it = f.begin(); it != f.end(); ++it) {
+            *it -= mean;
+        }
     }
     else
     {
@@ -676,6 +604,7 @@ std::size_t burg_method(InputIterator   data_first,
     {
         // Compute mu from f, b, and Dk and then update sigma2e and Ak using mu
         // Afterwards, Ak[1:kp1] contains AR(k) coefficients by the recurrence
+        // Must treat mu result of 0 / 0 as 0 to avoid NaNs on constant signals
         // By the recurrence, Ak[kp1] will also be the reflection coefficient
         Value mu = -2 * negative_half_reflection_coefficient<Value>(
                 f.begin() + kp1, f.end(), b.begin());
@@ -727,7 +656,91 @@ std::size_t burg_method(InputIterator   data_first,
     return N;
 }
 
-/** \copydoc burg_method(InputIterator,InputIterator,Value&,std::size_t&,OutputIterator1,OutputIterator2,OutputIterator3,OutputIterator4,const bool,const bool,Vector&,Vector&,Vector&,Vector&) */
+/**
+ * Fit an autoregressive model to stationary time series data using %Burg's
+ * method.  That is, find coefficients \f$a_i\f$ such that the sum of the
+ * squared errors in the forward predictions \f$x_n = -a_1 x_{n-1} - \dots -
+ * a_p x_{n-p}\f$ and backward predictions \f$x_n = -a_1 x_{n+1} - \dots - a_p
+ * x_{n+p}\f$ are both minimized.  Either a single model of given order or a
+ * hierarchy of models up to and including a maximum order may fit.
+ *
+ * The input data \f$\vec{x}\f$ are read from <tt>[data_first, data_last)</tt>
+ * in a single pass.  The mean is computed, returned in \c mean, and \e
+ * removed from further consideration whenever \c subtract_mean is true.
+ * The estimated model parameters \f$a_i\f$ are output using \c params_first
+ * with the behavior determined by the amount of data read, <tt>maxorder</tt>,
+ * and the \c hierarchy flag:
+ * <ul>
+ *     <li>If \c hierarchy is \c false, only the \f$a_1, \dots,
+ *         a_\text{maxorder}\f$ parameters for an AR(<tt>maxorder</tt>) process
+ *         are output.</li>
+ *     <li>If \c hierarchy is \c true, the <tt>maxorder*(maxorder+1)/2</tt>
+ *         parameters \f$a_1, \dots, a_m\f$ for models AR(0), AR(1), AR(2),
+ *         ..., AR(maxorder) are output.  Notice AR(0) has no parameters.
+ *         </li>
+ * </ul>
+ * Note that the latter case is \e always computed; the \c hierarchy flag
+ * merely controls what is output.  In both cases, the maximum order is limited
+ * by the number of data samples provided and is output to \c maxorder.
+ *
+ * One mean squared discrepancy \f$\sigma^2_\epsilon\f$, also called the
+ * innovation variance, and gain, defined as \f$\sigma^2_x /
+ * \sigma^2_\epsilon\f$, are output for each model, including the trivial
+ * zeroth order model when \c maxorder is zero or \c hierarchy is \c true,
+ * using \c sigma2e_first and \c gain_first.  The autocorrelations for lags
+ * <tt>[0,k]</tt> are output using \c autocor_first.  When \c hierarchy is \c
+ * true, only lags <tt>[0,m]</tt> should be applied for some AR(<tt>m</tt>)
+ * model.  Outputting the lag \c k autocorrelation is technically redundant as
+ * it may be computed from \f$a_i\f$ and lags <tt>0, ..., k-1</tt>.
+ * Autocovariances may be computed by multiplying the autocorrelations by the
+ * gain times \f$\sigma^2_\epsilon\f$.
+ *
+ * The software aspects of the implementation differs from many other sources.
+ * In particular,
+ * <ul>
+ *     <li>iterators are employed,</li>
+ *     <li>the working precision is selectable using \c mean,</li>
+ *     <li>the mean squared discrepancy calculation has been added,</li>
+ *     <li>some loop index transformations have been performed,</li>
+ *     <li>working storage may be passed into the method to reduce allocations
+ *     across many invocations (see overload with Vector parameters), and</li>
+ *     <li>and all lower order models may be output during the recursion using
+ *     \c hierarchy.</li>
+ * </ul>
+ * Gain and autocorrelation calculations have been added based on sections 5.2
+ * and 5.3 of Broersen, P.  M.  T. Automatic autocorrelation and spectral
+ * analysis.  Springer, 2006.  http://dx.doi.org/10.1007/1-84628-329-9.  The
+ * classical algorithm, rather than the variant using denominator recursion due
+ * to Andersen (http://dx.doi.org/10.1109/PROC.1978.11160), has been chosen as
+ * the latter can be numerically unstable.
+ *
+ * @param[in]     data_first    Beginning of the input data range.
+ * @param[in]     data_last     Exclusive end of the input data range.
+ * @param[out]    mean          Mean of data.
+ * @param[in,out] maxorder      On input, the maximum model order desired.
+ *                              On output, the maximum model order computed.
+ * @param[out]    params_first  Model parameters for a single model or
+ *                              for an entire hierarchy of models.  At most
+ *                              <tt>!hierarchy ? maxorder :
+ *                              maxorder*(maxorder+1)/2</tt> values will be
+ *                              output.
+ * @param[out]    sigma2e_first The mean squared discrepancy for only
+ *                              AR(<tt>maxorder</tt>) or for an entire
+ *                              hierarchy.  Either one or at most
+ *                              <tt>maxorder + 1</tt> values will be output.
+ * @param[out]    gain_first    The model gain for only AR(<tt>maxorder</tt>)
+ *                              or an entire hierarchy.  Either one or at most
+ *                              <tt>maxorder + 1</tt> values will be output.
+ * @param[out]    autocor_first Lag one through lag maxorder autocorrelations.
+ *                              At most <tt>maxorder + 1</tt> values will be
+ *                              output.
+ * @param[in]     subtract_mean Should \c mean be subtracted from the data?
+ * @param[in]     hierarchy     Should the entire hierarchy of estimated
+ *                              models be output?
+ *
+ * @returns the number data values processed within
+ *          <tt>[data_first, data_last)</tt>.
+ */
 template <class InputIterator,
           class Value,
           class OutputIterator1,
@@ -1615,9 +1628,9 @@ template <class EstimationMethod,
           typename Integer2 = Integer1>
 struct empirical_variance_function
 {
-    typedef Result   first_argument_type;
-    typedef Integer1 second_argument_type;
-    typedef Integer2 result_type;
+    typedef Integer1 first_argument_type;
+    typedef Integer2 second_argument_type;
+    typedef Result   result_type;
 
     Result operator() (Integer1 N, Integer2 i) const
     {
@@ -1673,7 +1686,6 @@ template <class EstimationMethod,
 class empirical_variance_iterator
 {
 private:
-
     Integer1 N;
     Integer2 i;
 
@@ -2101,7 +2113,7 @@ struct FSIC<YuleWalker<MeanHandling> > : public criterion
         Result v0  = YuleWalker<MeanHandling>
             ::template empirical_variance<Result>(N, Integer2(0));
         Result a = AR_POCHHAMMER(N*(N+3) - p, p);
-        Result b = AR_POCHHAMMER(Result(1 + N) - N*N);
+        Result b = AR_POCHHAMMER(Result(1 + N) - N*N, p);
 
         return (1 + v0) / (1 - v0) * (a / b) - 1;
     }
@@ -2371,10 +2383,10 @@ namespace { // anonymous
 struct null_output
 {
     typedef std::output_iterator_tag iterator_category;
-    typedef null_output              value_type;
-    typedef std::ptrdiff_t           difference_type;
-    typedef null_output*             pointer;
-    typedef null_output&             reference;
+    typedef void                     value_type;
+    typedef void                     difference_type;
+    typedef void                     pointer;
+    typedef void                     reference;
 
     template <typename T> void operator=(const T&) {}
 


### PR DESCRIPTION
This PR addresses several issues in the autoregressive analysis library:

## Summary
Multiple improvements to code quality, numerical stability, and documentation in the AR header file, including fixes for edge cases in reflection coefficient calculations, modernization of C++ idioms, and documentation corrections.

## Key Changes

- **Numerical Stability**: Enhanced `negative_half_reflection_coefficient()` to explicitly handle the zero numerator case, returning 0 instead of NaN when processing constant zero signals. This prevents undesired NaN propagation while maintaining NaN detection for actual data issues.

- **Documentation Improvements**:
  - Updated copyright year to include 2026
  - Fixed Doxygen markup in documentation (escaped `#define` as `\#define`)
  - Reorganized documentation for `burg_method()` overloads to avoid duplication using `\copydoc`
  - Enhanced comments explaining the zero numerator special case handling

- **Code Modernization**:
  - Replaced deprecated `std::bind2nd()` and `std::minus<>()` with explicit loop in mean subtraction
  - Removed unnecessary `using` declarations for deprecated STL adapters
  - Replaced `transform()` call with clearer explicit loop

- **Bug Fixes**:
  - Fixed `AR_POCHHAMMER` macro call in FSIC criterion (added missing second parameter `p`)
  - Corrected `empirical_variance_function` template typedef ordering to match functor signature
  - Fixed `null_output` iterator traits to use `void` instead of incorrect type assignments

- **Code Cleanup**:
  - Removed unnecessary blank line in `empirical_variance_iterator` class
  - Added clarifying comments in Burg's method implementation

## Implementation Details
The reflection coefficient fix uses a ternary operator to check if the numerator equals zero before division, preventing 0/0 NaN while allowing legitimate NaN detection when the denominator contains NaN from actual data issues.

https://claude.ai/code/session_015N2271bBPDmEqFPmRyDqEX